### PR TITLE
Ignore `stderr` when running `rofi`

### DIFF
--- a/main.go
+++ b/main.go
@@ -217,7 +217,7 @@ func runRofi(workspaces workspace.WorkspaceCollection) {
 		}
 	}()
 
-	out, err := cmd.CombinedOutput()
+	out, err := cmd.Output()
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Today after some system upgrades `rofi` on my system is outputting a warning on `stderr`[^*] which causes `rofi-code` to fail to open workspaces correctly.  Digging in to the code a little, it seems that it's the use of `CombinedOutput` that's causing the problem.  I think there's no reason why `stderr` should ever be passed to `codeCmd`?

Thanks!

[^*]: `Fontconfig warning: using without calling FcInit()` specifically, but that's not the point.